### PR TITLE
Decorate additional libjpeg symbols with FOXIT_PREFIX macro

### DIFF
--- a/third_party/libjpeg/cdjpeg.h
+++ b/third_party/libjpeg/cdjpeg.h
@@ -91,6 +91,27 @@ typedef struct cdjpeg_progress_mgr * cd_progress_ptr;
 
 /* Short forms of external names for systems with brain-damaged linkers. */
 
+#define jinit_read_bmp          FOXIT_PREFIX(jinit_read_bmp)
+#define jinit_write_bmp         FOXIT_PREFIX(jinit_write_bmp)
+#define jinit_read_gif          FOXIT_PREFIX(jinit_read_gif)
+#define jinit_write_gif         FOXIT_PREFIX(jinit_write_gif)
+#define jinit_read_ppm          FOXIT_PREFIX(jinit_read_ppm)
+#define jinit_write_ppm         FOXIT_PREFIX(jinit_write_ppm)
+#define jinit_read_rle          FOXIT_PREFIX(jinit_read_rle)
+#define jinit_write_rle         FOXIT_PREFIX(jinit_write_rle)
+#define jinit_read_targa        FOXIT_PREFIX(jinit_read_targa)
+#define jinit_write_targa       FOXIT_PREFIX(jinit_write_targa)
+#define read_quant_tables       FOXIT_PREFIX(read_quant_tables)
+#define read_scan_script        FOXIT_PREFIX(read_scan_script)
+#define set_quant_slots         FOXIT_PREFIX(set_quant_slots)
+#define set_sample_factors      FOXIT_PREFIX(set_sample_factors)
+#define read_color_map          FOXIT_PREFIX(read_color_map)
+#define enable_signal_catcher   FOXIT_PREFIX(enable_signal_catcher)
+#define start_progress_monitor  FOXIT_PREFIX(start_progress_monitor)
+#define end_progress_monitor    FOXIT_PREFIX(end_progress_monitor)
+#define read_stdin              FOXIT_PREFIX(read_stdin)
+#define write_stdout            FOXIT_PREFIX(write_stdout
+
 #ifdef NEED_SHORT_EXTERNAL_NAMES
 #define jinit_read_bmp		jIRdBMP
 #define jinit_write_bmp		jIWrBMP

--- a/third_party/libjpeg/fpdfapi_jerror.c
+++ b/third_party/libjpeg/fpdfapi_jerror.c
@@ -33,6 +33,8 @@
  * want to refer to it directly.
  */
 
+#define jpeg_std_message_table FOXIT_PREFIX(jpeg_std_message_table)
+
 #ifdef NEED_SHORT_EXTERNAL_NAMES
 #define jpeg_std_message_table	jMsgTable
 #endif

--- a/third_party/libjpeg/jpegint.h
+++ b/third_party/libjpeg/jpegint.h
@@ -293,6 +293,40 @@ struct jpeg_color_quantizer {
 
 /* Short forms of external names for systems with brain-damaged linkers. */
 
+#define jinit_compress_master   FOXIT_PREFIX(jinit_compress_master)
+#define jinit_c_master_control  FOXIT_PREFIX(jinit_c_master_control)
+#define jinit_c_main_controller FOXIT_PREFIX(jinit_c_main_controller)
+#define jinit_c_prep_controller FOXIT_PREFIX(jinit_c_prep_controller)
+#define jinit_c_coef_controller FOXIT_PREFIX(jinit_c_coef_controller)
+#define jinit_color_converter   FOXIT_PREFIX(jinit_color_converter)
+#define jinit_downsampler       FOXIT_PREFIX(jinit_downsampler)
+#define jinit_forward_dct       FOXIT_PREFIX(jinit_forward_dct)
+#define jinit_huff_encoder      FOXIT_PREFIX(jinit_huff_encoder)
+#define jinit_phuff_encoder     FOXIT_PREFIX(jinit_phuff_encoder)
+#define jinit_marker_writer     FOXIT_PREFIX(jinit_marker_writer)
+#define jinit_master_decompress FOXIT_PREFIX(jinit_master_decompress)
+#define jinit_d_main_controller FOXIT_PREFIX(jinit_d_main_controller)
+#define jinit_d_coef_controller FOXIT_PREFIX(jinit_d_coef_controller)
+#define jinit_d_post_controller FOXIT_PREFIX(jinit_d_post_controller)
+#define jinit_input_controller  FOXIT_PREFIX(jinit_input_controller)
+#define jinit_marker_reader     FOXIT_PREFIX(jinit_marker_reader)
+#define jinit_huff_decoder      FOXIT_PREFIX(jinit_huff_decoder)
+#define jinit_phuff_decoder     FOXIT_PREFIX(jinit_phuff_decoder)
+#define jinit_inverse_dct       FOXIT_PREFIX(jinit_inverse_dct)
+#define jinit_upsampler         FOXIT_PREFIX(jinit_upsampler)
+#define jinit_color_deconverter FOXIT_PREFIX(jinit_color_deconverter)
+#define jinit_1pass_quantizer   FOXIT_PREFIX(jinit_1pass_quantizer)
+#define jinit_2pass_quantizer   FOXIT_PREFIX(jinit_2pass_quantizer)
+#define jinit_merged_upsampler  FOXIT_PREFIX(jinit_merged_upsampler)
+#define jinit_memory_mgr        FOXIT_PREFIX(jinit_memory_mgr)
+#define jdiv_round_up           FOXIT_PREFIX(jdiv_round_up)
+#define jround_up               FOXIT_PREFIX(jround_up)
+#define jcopy_sample_rows       FOXIT_PREFIX(jcopy_sample_rows)
+#define jcopy_block_row         FOXIT_PREFIX(jcopy_block_row)
+#define jzero_far               FOXIT_PREFIX(jzero_far)
+#define jpeg_zigzag_order       FOXIT_PREFIX(jpeg_zigzag_order)
+#define jpeg_natural_order      FOXIT_PREFIX(jpeg_natural_order)
+
 #ifdef NEED_SHORT_EXTERNAL_NAMES
 #define jinit_compress_master	jICompress
 #define jinit_c_master_control	jICMaster

--- a/third_party/libjpeg/jpeglib.h
+++ b/third_party/libjpeg/jpeglib.h
@@ -80,6 +80,61 @@
 #define jround_up FOXIT_PREFIX(jround_up)
 #define jzero_far FOXIT_PREFIX(jzero_far)
 
+#define jpeg_CreateCompress     FOXIT_PREFIX(jpeg_CreateCompress)
+/*#define jpeg_CreateDecompress   FOXIT_PREFIX(jpeg_CreateDecompress)*/
+#define jpeg_destroy_compress   FOXIT_PREFIX(jpeg_destroy_compress)
+/*#define jpeg_destroy_decompress FOXIT_PREFIX(jpeg_destroy_decompress)*/
+#define jpeg_stdio_dest         FOXIT_PREFIX(jpeg_stdio_dest)
+/*#define jpeg_stdio_src          FOXIT_PREFIX(jpeg_stdio_src)*/
+#define jpeg_set_defaults       FOXIT_PREFIX(jpeg_set_defaults)
+#define jpeg_set_colorspace     FOXIT_PREFIX(jpeg_set_colorspace)
+#define jpeg_default_colorspace FOXIT_PREFIX(jpeg_default_colorspace)
+#define jpeg_set_quality        FOXIT_PREFIX(jpeg_set_quality)
+#define jpeg_set_linear_quality FOXIT_PREFIX(jpeg_set_linear_quality)
+#define jpeg_add_quant_table    FOXIT_PREFIX(jpeg_add_quant_table)
+#define jpeg_quality_scaling    FOXIT_PREFIX(jpeg_quality_scaling)
+#define jpeg_simple_progression FOXIT_PREFIX(jpeg_simple_progression)
+#define jpeg_suppress_tables    FOXIT_PREFIX(jpeg_suppress_tables)
+/*#define jpeg_alloc_quant_table  FOXIT_PREFIX(jpeg_alloc_quant_table)*/
+/*#define jpeg_alloc_huff_table   FOXIT_PREFIX(jpeg_alloc_huff_table)*/
+#define jpeg_start_compress     FOXIT_PREFIX(jpeg_start_compress)
+#define jpeg_write_scanlines    FOXIT_PREFIX(jpeg_write_scanlines)
+#define jpeg_finish_compress    FOXIT_PREFIX(jpeg_finish_compress)
+#define jpeg_write_raw_data     FOXIT_PREFIX(jpeg_write_raw_data)
+#define jpeg_write_marker       FOXIT_PREFIX(jpeg_write_marker)
+#define jpeg_write_m_header     FOXIT_PREFIX(jpeg_write_m_header)
+#define jpeg_write_m_byte       FOXIT_PREFIX(jpeg_write_m_byte)
+#define jpeg_write_tables       FOXIT_PREFIX(jpeg_write_tables)
+/*#define jpeg_read_header        FOXIT_PREFIX(jpeg_read_header)*/
+/*#define jpeg_start_decompress   FOXIT_PREFIX(jpeg_start_decompress)*/
+/*#define jpeg_read_scanlines     FOXIT_PREFIX(jpeg_read_scanlines)*/
+/*#define jpeg_finish_decompress  FOXIT_PREFIX(jpeg_finish_decompress)*/
+/*#define jpeg_read_raw_data      FOXIT_PREFIX(jpeg_read_raw_data)*/
+/*#define jpeg_has_multiple_scans FOXIT_PREFIX(jpeg_has_multiple_scans)*/
+/*#define jpeg_start_output       FOXIT_PREFIX(jpeg_start_output)*/
+/*#define jpeg_finish_output      FOXIT_PREFIX(jpeg_finish_output)*/
+/*#define jpeg_input_complete     FOXIT_PREFIX(jpeg_input_complete)*/
+/*#define jpeg_new_colormap       FOXIT_PREFIX(jpeg_new_colormap)*/
+/*#define jpeg_consume_input      FOXIT_PREFIX(jpeg_consume_input)*/
+/*#define jpeg_calc_output_dimensions     FOXIT_PREFIX(jpeg_calc_output_dimensions)*/
+/*#define jpeg_save_markers       FOXIT_PREFIX(jpeg_save_markers)*/
+/*#define jpeg_set_marker_processor       FOXIT_PREFIX(jpeg_set_marker_processor)*/
+/*#define jpeg_read_coefficients  FOXIT_PREFIX(jpeg_read_coefficients)*/
+#define jpeg_write_coefficients FOXIT_PREFIX(jpeg_write_coefficients)
+#define jpeg_copy_critical_parameters   FOXIT_PREFIX(jpeg_copy_critical_parameters)
+#define jpeg_abort_compress     FOXIT_PREFIX(jpeg_abort_compress)
+/*#define jpeg_abort_decompress   FOXIT_PREFIX(jpeg_abort_decompress)*/
+/*#define jpeg_abort              FOXIT_PREFIX(jpeg_abort)*/
+/*#define jpeg_destroy            FOXIT_PREFIX(jpeg_destroy)*/
+/*#define jpeg_resync_to_restart  FOXIT_PREFIX(jpeg_resync_to_restart)*/
+
+#define jpeg_fdct_islow         FOXIT_PREFIX(jpeg_fdct_islow)
+#define jpeg_fdct_ifast         FOXIT_PREFIX(jpeg_fdct_ifast)
+#define jpeg_fdct_float         FOXIT_PREFIX(jpeg_fdct_float)
+
+#define jpeg_make_c_derived_tbl         FOXIT_PREFIX(jpeg_make_c_derived_tbl)
+#define jpeg_gen_optimal_table          FOXIT_PREFIX(jpeg_gen_optimal_table)
+
  /*
  * First we include the configuration files that record how this
  * installation of the JPEG library is set up.  jconfig.h can be

--- a/third_party/libjpeg/transupp.h
+++ b/third_party/libjpeg/transupp.h
@@ -22,6 +22,12 @@
 #define TRANSFORMS_SUPPORTED 1		/* 0 disables transform code */
 #endif
 
+#define jtransform_request_workspace FOXIT_PREFIX(jtransform_request_workspace)
+#define jtransform_adjust_parameters FOXIT_PREFIX(jtransform_adjust_parameters)
+#define jtransform_execute_transformation FOXIT_PREFIX(jtransform_execute_transformation)
+#define jcopy_markers_setup FOXIT_PREFIX(jcopy_markers_setup)
+#define jcopy_markers_execute FOXIT_PREFIX(jcopy_markers_execute)
+
 /* Short forms of external names for systems with brain-damaged linkers. */
 
 #ifdef NEED_SHORT_EXTERNAL_NAMES


### PR DESCRIPTION
With those changes, there are no longer runtime conflicts when linking
pdfium with an application that links against another libjpeg.